### PR TITLE
Bump flyway.version from 10.14.0 to 10.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <java.version>21</java.version>
         <spring.boot.version>3.3.1</spring.boot.version> <!-- Keep this in sync with the parent version -->
-        <flyway.version>10.14.0</flyway.version>
+        <flyway.version>10.15.0</flyway.version>
         <jjwt.version>0.12.6</jjwt.version>
         <swagger.version>2.2.22</swagger.version>
     </properties>


### PR DESCRIPTION
Bumps `flyway.version` from 10.14.0 to 10.15.0.

Updates `org.flywaydb:flyway-core` from 10.14.0 to 10.15.0
- [Release notes](https://github.com/flyway/flyway/releases)
- [Commits](https://github.com/flyway/flyway/compare/flyway-10.14.0...flyway-10.15.0)

Updates `org.flywaydb:flyway-database-postgresql` from 10.14.0 to 10.15.0

---
updated-dependencies:
- dependency-name: org.flywaydb:flyway-core dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.flywaydb:flyway-database-postgresql dependency-type: direct:production update-type: version-update:semver-minor ...