### PR TITLE
49: More fixes

### DIFF
--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -28,7 +28,10 @@ spring:
       - override-me
   mail:
     host: override-me
-    port: override-me
+    port: 25 # Override me
+    username: override-me
+    password: override-me
+    default-encoding: UTF-8
 
 actuator:
   enabled: true
@@ -93,11 +96,11 @@ oxalate:
     cors-pattern: '/**'
     max-age: 3600
   captcha:
-    enabled: override-me
+    enabled: false # Override me
     verification-url: https://www.google.com/recaptcha/api/siteverify
     site-key: override-me
     secret-key: override-me
-    threshold: override-me
+    threshold: 0.1  # Override me
   token:
     expires-after: 12
     maxRetryCount: 3


### PR DESCRIPTION
*  Set the default spring.mail.default-encoding to UTF-8 which should allow us to use UTF-8 characters in the email subject correctly. Add the username, password to application.yaml for overriding