### PR TITLE
151

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ If you're looking for installation or management documentation, see the [documen
 
 ## Structure
 
-The project is a multimodule project where we've separated the REST API to [`api`](api/) module, while the server code is in [`service`](service/) module.
+The project is a multi-module project where we've separated the REST API to [`api`](api/) module, while the server code is in [`service`](service/) module.
 
 ## Application documentation
 

--- a/api/src/main/java/io/oxalate/backend/api/AbstractEvent.java
+++ b/api/src/main/java/io/oxalate/backend/api/AbstractEvent.java
@@ -2,7 +2,7 @@ package io.oxalate.backend.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Size;
-import java.sql.Timestamp;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -29,7 +29,7 @@ public abstract class AbstractEvent {
     private String description;
 
     @JsonProperty("startTime")
-    private Timestamp startTime;
+    private Instant startTime;
 
     @JsonProperty("eventDuration")
     private int eventDuration;

--- a/api/src/main/java/io/oxalate/backend/api/request/CertificateRequest.java
+++ b/api/src/main/java/io/oxalate/backend/api/request/CertificateRequest.java
@@ -3,7 +3,7 @@ package io.oxalate.backend.api.request;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.sql.Timestamp;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -40,5 +40,5 @@ public class CertificateRequest {
     @Schema(description = "Certification date in yyyy-mm-dd format", example = "2012-06-21", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty("certificationDate")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private Timestamp certificationDate;
+    private Instant certificationDate;
 }

--- a/api/src/main/java/io/oxalate/backend/api/request/EventRequest.java
+++ b/api/src/main/java/io/oxalate/backend/api/request/EventRequest.java
@@ -7,20 +7,22 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Schema(description = "Event update request")
 @SuperBuilder
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class EventRequest extends AbstractEvent {
 
-    @Schema(description = "Boolean to either show or hide the event, is effective only for upcoming events", example = "yes", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "Status of the event, is effective only for upcoming events", example = "PUBLISHED", requiredMode = Schema.RequiredMode.REQUIRED)
     @JsonProperty("status")
     private EventStatusEnum status;
 
     @Schema(description = "User ID of the organizer", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
-    @JsonProperty("organizer")
+    @JsonProperty("organizerId")
     private long organizerId;
 
     @Schema(description = "List of user ID of participating to the event", example = "[123, 234, 345]", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/service/src/main/java/io/oxalate/backend/controller/TestController.java
+++ b/service/src/main/java/io/oxalate/backend/controller/TestController.java
@@ -22,7 +22,6 @@ import io.oxalate.backend.service.PortalConfigurationService;
 import io.oxalate.backend.service.RoleService;
 import io.oxalate.backend.service.UserService;
 import jakarta.persistence.EntityManager;
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
@@ -159,7 +158,7 @@ public class TestController implements TestAPI {
                     .certificateName(getDiveCertificationPrefix() + " " + getDiveCertificationName())
                     .certificateId(RandomStringUtils.randomAlphabetic(7))
                     .diverId(RandomStringUtils.randomAlphabetic(7))
-                    .certificationDate(Timestamp.from(createDate.minus(RandomUtils.nextLong(100, 5000), ChronoUnit.DAYS)))
+                    .certificationDate(createDate.minus(RandomUtils.nextLong(100, 5000), ChronoUnit.DAYS))
                     .build();
             while (certificateService.findCertificateByUserOrgAndCertification(user.getId(), certificateRequest.getOrganization(),
                     certificateRequest.getCertificateName()) != null) {
@@ -168,7 +167,7 @@ public class TestController implements TestAPI {
                         .certificateName(getDiveCertificationPrefix() + " " + getDiveCertificationName())
                         .certificateId(RandomStringUtils.randomAlphabetic(7))
                         .diverId(RandomStringUtils.randomAlphabetic(7))
-                        .certificationDate(Timestamp.from(createDate.minus(RandomUtils.nextLong(100, 5000), ChronoUnit.DAYS)))
+                        .certificationDate(createDate.minus(RandomUtils.nextLong(100, 5000), ChronoUnit.DAYS))
                         .build();
             }
 
@@ -234,7 +233,7 @@ public class TestController implements TestAPI {
                 .maxDuration(RandomUtils.nextInt(30, 240))
                 .maxDepth(RandomUtils.nextInt(30, 180))
                 .maxParticipants(eventSize)
-                .startTime(Timestamp.from(createInstant))
+                .startTime(createInstant)
                 .organizerId(organizerId)
                 .status(EventStatusEnum.PUBLISHED)
                 .type(getEventType())
@@ -277,8 +276,8 @@ public class TestController implements TestAPI {
                 + "        OR (p.payment_type = 'ONE_TIME' AND p.payment_count > 0))";
 
         var query = entityManager.createNativeQuery(queryString);
-        query.setParameter("currentTime", Timestamp.from(createInstant));
-        List results = query.getResultList();
+        query.setParameter("currentTime", createInstant);
+        var results = query.getResultList();
 
         if (results.isEmpty()) {
             return;
@@ -427,7 +426,7 @@ public class TestController implements TestAPI {
             if (event.getType().equals("Vain pintatoimintaa")) {
                 addEventPaymentFromUser(participantId);
             } else {
-                deductEventPaymentFromUser(participantId, event.getStartTime().toInstant());
+                deductEventPaymentFromUser(participantId, event.getStartTime());
             }
 
             var optionalParticipant = userService.findUserById(participantId);

--- a/service/src/main/java/io/oxalate/backend/model/Certificate.java
+++ b/service/src/main/java/io/oxalate/backend/model/Certificate.java
@@ -8,7 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.sql.Timestamp;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,7 +45,7 @@ public class Certificate {
     private String diverId;
 
     @Column(name = "certification_date")
-    private Timestamp certificationDate;
+    private Instant certificationDate;
 
     public CertificateResponse toCertificateResponse() {
         return CertificateResponse.builder()
@@ -55,7 +55,7 @@ public class Certificate {
                                   .certificateName(this.certificateName)
                                   .certificateId(this.certificateId)
                                   .diverId(this.diverId)
-                                  .certificationDate(this.certificationDate.toInstant())
+                                  .certificationDate(this.certificationDate)
                                   .build();
     }
 
@@ -67,7 +67,7 @@ public class Certificate {
                                           .certificateName(this.certificateName)
                                           .certificateId(this.certificateId)
                                           .diverId(this.diverId)
-                                          .certificationDate(this.certificationDate.toInstant())
+                                          .certificationDate(this.certificationDate)
                                           .memberName(null)
                                           .build();
     }

--- a/service/src/main/java/io/oxalate/backend/model/Event.java
+++ b/service/src/main/java/io/oxalate/backend/model/Event.java
@@ -12,7 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
-import java.sql.Timestamp;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -44,7 +44,7 @@ public class Event {
     private String description;
 
     @Column(name = "start_time")
-    private Timestamp startTime;
+    private Instant startTime;
 
     @Column(name = "event_duration")
     private int eventDuration;

--- a/service/src/main/java/io/oxalate/backend/repository/EventRepository.java
+++ b/service/src/main/java/io/oxalate/backend/repository/EventRepository.java
@@ -2,7 +2,6 @@ package io.oxalate.backend.repository;
 
 import io.oxalate.backend.api.EventStatusEnum;
 import io.oxalate.backend.model.Event;
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
 import org.springframework.data.jpa.repository.Modifying;
@@ -13,9 +12,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EventRepository extends CrudRepository<Event, Long> {
-    List<Event> findByStartTimeAfterOrderByStartTimeAsc(Timestamp timestamp);
+    List<Event> findByStartTimeAfterOrderByStartTimeAsc(Instant instant);
 
-    List<Event> findByStatusAndStartTimeAfterOrderByStartTimeAsc(EventStatusEnum status, Timestamp timestamp);
+    List<Event> findByStatusAndStartTimeAfterOrderByStartTimeAsc(EventStatusEnum status, Instant instant);
 
     @Query(nativeQuery = true, value = "SELECT * FROM events e WHERE e.start_time < :until ORDER BY e.start_time DESC")
     List<Event> findAllEventsBefore(Instant until);

--- a/service/src/main/java/io/oxalate/backend/service/CertificateService.java
+++ b/service/src/main/java/io/oxalate/backend/service/CertificateService.java
@@ -11,7 +11,6 @@ import io.oxalate.backend.repository.CertificateRepository;
 import io.oxalate.backend.repository.filetransfer.CertificateDocumentRepository;
 import jakarta.transaction.Transactional;
 import java.nio.file.Paths;
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -154,7 +153,7 @@ public class CertificateService {
             certificate.setDiverId(UUID.randomUUID().toString());
             certificate.setCertificateId(UUID.randomUUID().toString());
             certificate.setCertificateName(UUID.randomUUID().toString());
-            certificate.setCertificationDate(Timestamp.from(Instant.ofEpochSecond(31337)));
+            certificate.setCertificationDate(Instant.ofEpochSecond(31337));
         }
 
         certificateRepository.saveAll(certificates);

--- a/service/src/main/java/io/oxalate/backend/service/EventService.java
+++ b/service/src/main/java/io/oxalate/backend/service/EventService.java
@@ -18,7 +18,6 @@ import io.oxalate.backend.model.User;
 import io.oxalate.backend.repository.EventParticipantsRepository;
 import io.oxalate.backend.repository.EventRepository;
 import jakarta.transaction.Transactional;
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -183,17 +182,17 @@ public class EventService {
     /**
      * Returns all events that have status PUBLISHED and have a start time after the given timestamp
      *
-     * @param timestamp Timestamp The timestamp after which the events should have started
+     * @param instant Instant The instant after which the events should have started
      * @param allEvents boolean Whether to return all events or only published ones
      * @return List<EventResponse>
      */
-    public List<EventResponse> findAllEventsAfter(Timestamp timestamp, boolean allEvents) {
+    public List<EventResponse> findAllEventsAfter(Instant instant, boolean allEvents) {
         List<Event> events;
 
         if (allEvents) {
-            events = eventRepository.findByStartTimeAfterOrderByStartTimeAsc(timestamp);
+            events = eventRepository.findByStartTimeAfterOrderByStartTimeAsc(instant);
         } else {
-            events = eventRepository.findByStatusAndStartTimeAfterOrderByStartTimeAsc(EventStatusEnum.PUBLISHED, timestamp);
+            events = eventRepository.findByStatusAndStartTimeAfterOrderByStartTimeAsc(EventStatusEnum.PUBLISHED, instant);
         }
 
         var eventResponses = new ArrayList<EventResponse>();

--- a/service/src/main/java/io/oxalate/backend/service/StatsService.java
+++ b/service/src/main/java/io/oxalate/backend/service/StatsService.java
@@ -8,7 +8,6 @@ import io.oxalate.backend.api.response.stats.MultiYearValue;
 import io.oxalate.backend.api.response.stats.YearlyDiversListResponse;
 import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.Year;
 import java.util.ArrayList;
@@ -267,14 +266,14 @@ public class StatsService {
 
         for (Object[] o : results) {
             var eventId = (Long) o[0];
-            var eventDateTime = (Timestamp) o[1];
+            var eventDateTime = (Instant) o[1];
             var organizerName = (String) o[2];
             var eventCount = (Long) o[3];
             var diveCount = (Long) o[4];
 
             var response = EventReportResponse.builder()
                                               .eventId(eventId)
-                                              .eventDateTime(eventDateTime.toInstant())
+                                              .eventDateTime(eventDateTime)
                                               .organizerName(organizerName)
                                               .participantCount(eventCount.intValue())
                                               .diveCount(diveCount.intValue())

--- a/service/src/main/java/io/oxalate/backend/service/filetransfer/DiveFileTransferService.java
+++ b/service/src/main/java/io/oxalate/backend/service/filetransfer/DiveFileTransferService.java
@@ -75,10 +75,7 @@ public class DiveFileTransferService {
         // Check that the event is in the future
         var event = eventService.findById(eventId);
         // If the event start time is in the past, then fail
-        // First convert the timestamp to an Instant
-        var eventStartTime = Instant.ofEpochMilli(event.getStartTime().getTime());
-
-        if (eventStartTime.isBefore(Instant.now())) {
+        if (event.getStartTime().isBefore(Instant.now())) {
             log.error("Event is in the past: {}", eventId);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Event is in the past");
         }

--- a/service/src/main/resources/db/migration/V18__Add_timezone_configuration.sql
+++ b/service/src/main/resources/db/migration/V18__Add_timezone_configuration.sql
@@ -1,0 +1,3 @@
+INSERT INTO portal_configuration (value_type, group_key, setting_key, default_value, runtime_value, required_runtime,description)
+VALUES
+    ('timezone',  'general',  'timezone', 'Europe/Helsinki', NULL, false, 'Portal timezone in which all date times should be displayed')


### PR DESCRIPTION
This pull request includes several changes to update the codebase by replacing `Timestamp` with `Instant` for date and time handling. Additionally, it includes minor improvements to variable naming and documentation.

### Date and Time Handling Updates:
* [`api/src/main/java/io/oxalate/backend/api/AbstractEvent.java`](diffhunk://#diff-9c405dc4e3a2bd1d518840057bd7fd0e4b74c4cf69ed6dd10c8aa617bef163edL5-R5): Replaced `Timestamp` with `Instant` for the `startTime` field. [[1]](diffhunk://#diff-9c405dc4e3a2bd1d518840057bd7fd0e4b74c4cf69ed6dd10c8aa617bef163edL5-R5) [[2]](diffhunk://#diff-9c405dc4e3a2bd1d518840057bd7fd0e4b74c4cf69ed6dd10c8aa617bef163edL32-R32)
* [`api/src/main/java/io/oxalate/backend/api/request/CertificateRequest.java`](diffhunk://#diff-5984a8db52ed94a8d37d2419f2b4655e3133e02de2fa4f307e3cb19ea4f63df0L6-R6): Replaced `Timestamp` with `Instant` for the `certificationDate` field. [[1]](diffhunk://#diff-5984a8db52ed94a8d37d2419f2b4655e3133e02de2fa4f307e3cb19ea4f63df0L6-R6) [[2]](diffhunk://#diff-5984a8db52ed94a8d37d2419f2b4655e3133e02de2fa4f307e3cb19ea4f63df0L43-R43)
* [`service/src/main/java/io/oxalate/backend/controller/EventController.java`](diffhunk://#diff-d25a598b073295fe2993edf34dcb7766817a19f86635496f2088c35fbc2d6af3L74): Replaced `Timestamp` with `Instant` in several methods for better date handling. [[1]](diffhunk://#diff-d25a598b073295fe2993edf34dcb7766817a19f86635496f2088c35fbc2d6af3L74) [[2]](diffhunk://#diff-d25a598b073295fe2993edf34dcb7766817a19f86635496f2088c35fbc2d6af3L109-R108) [[3]](diffhunk://#diff-d25a598b073295fe2993edf34dcb7766817a19f86635496f2088c35fbc2d6af3L216-R215) [[4]](diffhunk://#diff-d25a598b073295fe2993edf34dcb7766817a19f86635496f2088c35fbc2d6af3L274-R274)
* [`service/src/main/java/io/oxalate/backend/controller/TestController.java`](diffhunk://#diff-b2c7afe928f463533f3cc4b3278d913ca62e898ee80c247f4758fcffd0550506L25): Updated methods to use `Instant` instead of `Timestamp` for certification dates and event start times. [[1]](diffhunk://#diff-b2c7afe928f463533f3cc4b3278d913ca62e898ee80c247f4758fcffd0550506L25) [[2]](diffhunk://#diff-b2c7afe928f463533f3cc4b3278d913ca62e898ee80c247f4758fcffd0550506L162-R161) [[3]](diffhunk://#diff-b2c7afe928f463533f3cc4b3278d913ca62e898ee80c247f4758fcffd0550506L171-R170) [[4]](diffhunk://#diff-b2c7afe928f463533f3cc4b3278d913ca62e898ee80c247f4758fcffd0550506L237-R236) [[5]](diffhunk://#diff-b2c7afe928f463533f3cc4b3278d913ca62e898ee80c247f4758fcffd0550506L280-R280) [[6]](diffhunk://#diff-b2c7afe928f463533f3cc4b3278d913ca62e898ee80c247f4758fcffd0550506L430-R429)
* [`service/src/main/java/io/oxalate/backend/model/Certificate.java`](diffhunk://#diff-9a9d636487dc3b63b0d6995d3e582635a103481908bb58c62d56fe6d368477d3L11-R11): Replaced `Timestamp` with `Instant` for the `certificationDate` field. [[1]](diffhunk://#diff-9a9d636487dc3b63b0d6995d3e582635a103481908bb58c62d56fe6d368477d3L11-R11) [[2]](diffhunk://#diff-9a9d636487dc3b63b0d6995d3e582635a103481908bb58c62d56fe6d368477d3L48-R48) [[3]](diffhunk://#diff-9a9d636487dc3b63b0d6995d3e582635a103481908bb58c62d56fe6d368477d3L58-R58) [[4]](diffhunk://#diff-9a9d636487dc3b63b0d6995d3e582635a103481908bb58c62d56fe6d368477d3L70-R70)
* [`service/src/main/java/io/oxalate/backend/model/Event.java`](diffhunk://#diff-cd102781f910432ced398fd6cb7006bdc410797f91861d7967a575239c99cc83L15-R15): Replaced `Timestamp` with `Instant` for the `startTime` field. [[1]](diffhunk://#diff-cd102781f910432ced398fd6cb7006bdc410797f91861d7967a575239c99cc83L15-R15) [[2]](diffhunk://#diff-cd102781f910432ced398fd6cb7006bdc410797f91861d7967a575239c99cc83L47-R47)
* [`service/src/main/java/io/oxalate/backend/repository/EventRepository.java`](diffhunk://#diff-f6f06057f5c4483359227cf5d60987562a3885e19585b9e7e36b042eb4122425L5): Updated methods to use `Instant` instead of `Timestamp` for querying event start times. [[1]](diffhunk://#diff-f6f06057f5c4483359227cf5d60987562a3885e19585b9e7e36b042eb4122425L5) [[2]](diffhunk://#diff-f6f06057f5c4483359227cf5d60987562a3885e19585b9e7e36b042eb4122425L16-R17)
* [`service/src/main/java/io/oxalate/backend/service/CertificateService.java`](diffhunk://#diff-bf08bc2bf044dc5010d32103c6429b4a0747d1bcadcd37affc07b9af4db7c39cL14): Replaced `Timestamp` with `Instant` for the `certificationDate` field in the `anonymize` method. [[1]](diffhunk://#diff-bf08bc2bf044dc5010d32103c6429b4a0747d1bcadcd37affc07b9af4db7c39cL14) [[2]](diffhunk://#diff-bf08bc2bf044dc5010d32103c6429b4a0747d1bcadcd37affc07b9af4db7c39cL157-R156)
* [`service/src/main/java/io/oxalate/backend/service/EventService.java`](diffhunk://#diff-63e76aedbcf86c05ab0462cea9a0f7114400c4505385e76ccaba850ff101d008L21): Updated methods to use `Instant` instead of `Timestamp` for event start times. [[1]](diffhunk://#diff-63e76aedbcf86c05ab0462cea9a0f7114400c4505385e76ccaba850ff101d008L21) [[2]](diffhunk://#diff-63e76aedbcf86c05ab0462cea9a0f7114400c4505385e76ccaba850ff101d008L186-R195)
* [`service/src/main/java/io/oxalate/backend/service/StatsService.java`](diffhunk://#diff-f4d060648d501dbddb83fcbe069b581f02745f8799336297d8b83eb7c612d376L11): Replaced `Timestamp` with `Instant` for date handling.

### Documentation and Naming Improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R7): Corrected a typo from "multimodule" to "multi-module."
* [`api/src/main/java/io/oxalate/backend/api/request/EventRequest.java`](diffhunk://#diff-82c8ac7fa629c352ee1c334309bc69cb809f198ebc05ed47eaa7e9584c75d13cR10-R25): Improved variable names for better clarity.