### PR TITLE
139

### DIFF
--- a/api/src/main/java/io/oxalate/backend/api/request/BlockedDateRequest.java
+++ b/api/src/main/java/io/oxalate/backend/api/request/BlockedDateRequest.java
@@ -12,6 +12,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class BlockedDateRequest {
-    @JsonProperty("blockedDate")
+    @JsonProperty(value = "blockedDate", required = true)
     private Date blockedDate;
+    @JsonProperty(value = "reason", required = true)
+    private String reason;
 }

--- a/api/src/main/java/io/oxalate/backend/api/response/BlockedDateResponse.java
+++ b/api/src/main/java/io/oxalate/backend/api/response/BlockedDateResponse.java
@@ -19,6 +19,8 @@ public class BlockedDateResponse {
     private Date blockedDate;
     @JsonProperty("createdAt")
     private Instant createdAt;
-    @JsonProperty("creator")
-    private long creator;
+    @JsonProperty("creatorName")
+    private String creatorName;
+    @JsonProperty("reason")
+    private String reason;
 }

--- a/service/src/main/java/io/oxalate/backend/model/BlockedDate.java
+++ b/service/src/main/java/io/oxalate/backend/model/BlockedDate.java
@@ -38,12 +38,16 @@ public class BlockedDate {
     @Column(name = "creator", nullable = false)
     private long creator;
 
+    @Column(name = "reason", nullable = false)
+    private String reason;
+
     public BlockedDateResponse toResponse() {
         return BlockedDateResponse.builder()
                                   .id(this.id)
                                   .blockedDate(this.blockedDate)
                                   .createdAt(this.createdAt)
-                                  .creator(this.creator)
+                                  .creatorName(null)
+                                  .reason(this.reason)
                                   .build();
     }
 }

--- a/service/src/main/resources/db/migration/V19__Add_reason_to_blocked_date.sql
+++ b/service/src/main/resources/db/migration/V19__Add_reason_to_blocked_date.sql
@@ -1,0 +1,2 @@
+ALTER TABLE blocked_dates
+    ADD COLUMN reason TEXT DEFAULT 'Not specified' NOT NULL;


### PR DESCRIPTION
This pull request introduces several changes to handle the inclusion of a `reason` field in the `BlockedDate` model and its related classes. Additionally, it updates the way creator information is stored and retrieved.

### Changes to `BlockedDate` model and related classes:

* [`BlockedDateRequest.java`](diffhunk://#diff-f04aef7f3adad0ba1dcbb679b0c43aade05fbf9b5ea451b1665604d1010448a4L15-R18): Added a new `reason` field with the `@JsonProperty` annotation set to `required = true`.
* [`BlockedDateResponse.java`](diffhunk://#diff-006cba6477956cead596b7ff27ac31f113f17eb658dd5f5def5b758fd13af5e8L22-R25): Changed the `creator` field to `creatorName` and added a new `reason` field.
* [`BlockedDate.java`](diffhunk://#diff-d486d1d021701915bc7d8f5862ccb8f9d0f186302dcf4ee3a4b73fa922639398R41-R50): Added a new `reason` field with a corresponding column in the database. Updated the `toResponse` method to include `creatorName` and `reason`.

### Service layer updates:

* `BlockedDateService.java`: 
  * Introduced a `UserService` dependency to fetch user details.
  * Modified the `createBlock` method to include the `reason` field.
  * Added a `populateResponse` private method to set the `creatorName` in the `BlockedDateResponse`. [[1]](diffhunk://#diff-d156795cb26b69c9431501320babaa8643833a38302840fa40b482e170868dd3R21-R29) [[2]](diffhunk://#diff-d156795cb26b69c9431501320babaa8643833a38302840fa40b482e170868dd3R40-R43) [[3]](diffhunk://#diff-d156795cb26b69c9431501320babaa8643833a38302840fa40b482e170868dd3R55-R68)

### Database migration:

* [`V19__Add_reason_to_blocked_date.sql`](diffhunk://#diff-fe977c3e4a9af0d13ba32ba719727b6139e730c22c6674cf70b9ff06140a0be1R1-R2): Added a new `reason` column to the `blocked_dates` table with a default value of 'Not specified'.