### PR TITLE
Filter non-published page groups from navi bar

### DIFF
--- a/service/src/main/java/io/oxalate/backend/service/PageService.java
+++ b/service/src/main/java/io/oxalate/backend/service/PageService.java
@@ -120,6 +120,10 @@ public class PageService {
         log.debug("Got list of page groups before filtering with lang {}: {}", language, pageGroups);
 
         for (var pageGroup : pageGroups) {
+            if (!pageGroup.getStatus().equals(PageStatusEnum.PUBLISHED)) {
+                continue;
+            }
+
             populatePageGroup(pageGroup, language);
 
             // Check that the user has access to the pages


### PR DESCRIPTION
This pull request introduces a small but important change to the `getPageGroups` method in `PageService.java`. The change ensures that only page groups with a `PUBLISHED` status are processed and returned, improving the accuracy and security of the results.

* Added a filter to skip any `PageGroup` that does not have a `PUBLISHED` status in the `getPageGroups` method of `PageService.java`.