### PR TITLE
Certificate user ID fix

### DIFF
--- a/service/src/main/java/io/oxalate/backend/service/filetransfer/CertificateFileTransferService.java
+++ b/service/src/main/java/io/oxalate/backend/service/filetransfer/CertificateFileTransferService.java
@@ -175,7 +175,7 @@ public class CertificateFileTransferService {
         // Get the certificate and check that the user ID matches with the given userId
         var optionalCertificate = certificateRepository.findById(certificateId);
         if (optionalCertificate.isEmpty()) {
-            log.error("Certificate not found: {}", certificateId);
+            log.error("Certificate to download not found: {}", certificateId);
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Certificate not found");
         }
 
@@ -198,11 +198,11 @@ public class CertificateFileTransferService {
 
         var certificateDocument = optionalCertificateDocument.get();
         var fileName = certificateDocument.getFileName();
-        var uploadPath = Paths.get(uploadMainDirectory, UploadDirectoryConstants.CERTIFICATES, String.valueOf(userId), fileName);
+        var uploadPath = Paths.get(uploadMainDirectory, UploadDirectoryConstants.CERTIFICATES, String.valueOf(certificate.getUserId()), fileName);
         var file = uploadPath.toFile();
 
         if (!file.exists()) {
-            log.error("File not found on filesystem: {}", file);
+            log.error("File to download not found on filesystem: {}", file);
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "File not found");
         }
 


### PR DESCRIPTION
This pull request makes minor improvements to error logging in the `CertificateFileTransferService` class. The changes clarify log messages when a certificate or its file is not found, and ensure the file path is constructed using the certificate owner's user ID instead of the requester's user ID.

Most important changes:

**Error logging improvements:**
* Updated log messages to clarify when a certificate or file is missing during download operations. [[1]](diffhunk://#diff-ae8e792535b1c8989bfc3dec2e9895924955fb13e1c642172a8749ca7644b34fL178-R178) [[2]](diffhunk://#diff-ae8e792535b1c8989bfc3dec2e9895924955fb13e1c642172a8749ca7644b34fL201-R205)

**File path construction:**
* Changed the file path construction to use `certificate.getUserId()` instead of the provided `userId`, ensuring the correct directory is targeted for certificate file downloads.