### PR TITLE
Add debugging around payment handling in order to see why the payment period calculation fails

### DIFF
--- a/service/src/main/java/io/oxalate/backend/service/PaymentService.java
+++ b/service/src/main/java/io/oxalate/backend/service/PaymentService.java
@@ -173,6 +173,7 @@ public class PaymentService {
         var now = LocalDate.now();
         var userId = paymentRequest.getUserId();
         var effectivePaymentMode = getEffectivePaymentMode();
+        log.debug("saveOneTimePayment called with request={}, now={}, effectivePaymentMode={}", paymentRequest, now, effectivePaymentMode);
 
         if (effectivePaymentMode.equals(PeriodicPaymentTypeEnum.DISABLED)) {
             log.warn("Payment creation/update is disabled by configuration, skipping one-time payment handling");
@@ -243,6 +244,7 @@ public class PaymentService {
 
         var requestedStartDate = paymentRequest.getStartDate() != null ? paymentRequest.getStartDate() : now;
         var requestedEndDate = resolveRequestedOrCalculatedEndDate(paymentRequest, PaymentTypeEnum.ONE_TIME, effectivePaymentMode, requestedStartDate);
+        log.debug("saveOneTimePayment resolved requestedStartDate={}, requestedEndDate={} for userId={}", requestedStartDate, requestedEndDate, userId);
 
         var oneTimePayments = paymentRepository.findAllByUserIdAndPaymentType(userId, ONE_TIME);
         var overlappingOnePayments = oneTimePayments.stream()
@@ -267,6 +269,7 @@ public class PaymentService {
                              .build();
 
         var newPayment = paymentRepository.save(payment);
+        log.debug("saveOneTimePayment persisted payment={}", newPayment);
 
         return newPayment.toPaymentResponse();
     }
@@ -283,6 +286,7 @@ public class PaymentService {
         var now = LocalDate.now();
         var userId = paymentRequest.getUserId();
         var effectivePaymentMode = getEffectivePaymentMode();
+        log.debug("savePeriodPayment called with request={}, now={}, effectivePaymentMode={}", paymentRequest, now, effectivePaymentMode);
 
         if (effectivePaymentMode.equals(PeriodicPaymentTypeEnum.DISABLED)) {
             log.warn("Payment creation/update is disabled by configuration, skipping periodical payment handling");
@@ -291,6 +295,7 @@ public class PaymentService {
 
         var requestedStartDate = paymentRequest.getStartDate() != null ? paymentRequest.getStartDate() : now;
         var requestedEndDate = resolveRequestedOrCalculatedEndDate(paymentRequest, PaymentTypeEnum.PERIODICAL, effectivePaymentMode, requestedStartDate);
+        log.debug("savePeriodPayment resolved requestedStartDate={}, requestedEndDate={} for userId={}", requestedStartDate, requestedEndDate, userId);
 
         var periodicalPayments = paymentRepository.findAllByUserIdAndPaymentType(userId, PERIODICAL);
         var overlappingPeriodPayments = periodicalPayments.stream()
@@ -328,6 +333,7 @@ public class PaymentService {
                              .build();
 
         var newPayment = paymentRepository.save(payment);
+        log.debug("savePeriodPayment persisted payment={}", newPayment);
 
         return newPayment.toPaymentResponse();
     }
@@ -417,26 +423,34 @@ public class PaymentService {
     }
 
     private PeriodicPaymentTypeEnum getEffectivePaymentMode() {
-        var oneTimeExpirationType = normalizePeriodicType(
-                portalConfigurationService.getEnumConfiguration(PAYMENT.group, ONE_TIME_PAYMENT_EXPIRATION_TYPE.key));
-        var periodicalMethodType = normalizePeriodicType(
-                portalConfigurationService.getEnumConfiguration(PAYMENT.group, PERIODICAL_PAYMENT_METHOD_TYPE.key));
+        var rawOneTimeExpirationType = portalConfigurationService.getEnumConfiguration(PAYMENT.group, ONE_TIME_PAYMENT_EXPIRATION_TYPE.key);
+        var rawPeriodicalMethodType = portalConfigurationService.getEnumConfiguration(PAYMENT.group, PERIODICAL_PAYMENT_METHOD_TYPE.key);
+        var oneTimeExpirationType = normalizePeriodicType(rawOneTimeExpirationType);
+        var periodicalMethodType = normalizePeriodicType(rawPeriodicalMethodType);
+
+        log.debug(
+                "getEffectivePaymentMode rawOneTimeExpirationType={}, rawPeriodicalMethodType={}, normalizedOneTimeExpirationType={}, normalizedPeriodicalMethodType={}",
+                rawOneTimeExpirationType, rawPeriodicalMethodType, oneTimeExpirationType, periodicalMethodType);
 
         if (oneTimeExpirationType.equals(PeriodicPaymentTypeEnum.DISABLED)
                 || periodicalMethodType.equals(PeriodicPaymentTypeEnum.DISABLED)) {
+            log.debug("getEffectivePaymentMode resolved DISABLED because at least one payment mode is disabled");
             return PeriodicPaymentTypeEnum.DISABLED;
         }
 
         if (oneTimeExpirationType.equals(PeriodicPaymentTypeEnum.PERPETUAL)
                 || periodicalMethodType.equals(PeriodicPaymentTypeEnum.PERPETUAL)) {
+            log.debug("getEffectivePaymentMode resolved PERPETUAL because at least one payment mode is perpetual");
             return PeriodicPaymentTypeEnum.PERPETUAL;
         }
 
+        log.debug("getEffectivePaymentMode resolved {}", oneTimeExpirationType);
         return oneTimeExpirationType;
     }
 
     private LocalDate calculateEndDateForMode(PaymentTypeEnum paymentType, PeriodicPaymentTypeEnum paymentMode, LocalDate calculationDate) {
         if (paymentMode.equals(PeriodicPaymentTypeEnum.PERPETUAL)) {
+            log.debug("calculateEndDateForMode returning null for perpetual mode, paymentType={}, calculationDate={}", paymentType, calculationDate);
             return null;
         }
 
@@ -462,8 +476,14 @@ public class PaymentService {
         var periodStart = portalConfigurationService.getNumericConfiguration(PAYMENT.group, PAYMENT_PERIOD_START_POINT.key);
         var periodAnchor = LocalDate.parse(portalConfigurationService.getStringConfiguration(PAYMENT.group, PAYMENT_PERIOD_START.key));
 
-        return PeriodTools.calculatePeriod(calculationDate, periodAnchor, chronoUnit, periodStart, unitCount)
-                         .getEndDate();
+        log.debug(
+                "calculateEndDateForMode called with paymentType={}, paymentMode={}, calculationDate={}, useSharedPeriodConfig={}, chronoUnit={}, unitCount={}, periodStart={}, periodAnchor={}",
+                paymentType, paymentMode, calculationDate, useSharedPeriodConfig, chronoUnit, unitCount, periodStart, periodAnchor);
+
+        var periodResult = PeriodTools.calculatePeriod(calculationDate, periodAnchor, chronoUnit, periodStart, unitCount);
+        log.debug("calculateEndDateForMode resolved periodResult={}", periodResult);
+
+        return periodResult.getEndDate();
     }
 
     private LocalDate resolveRequestedOrCalculatedEndDate(PaymentRequest paymentRequest,
@@ -471,15 +491,21 @@ public class PaymentService {
             PeriodicPaymentTypeEnum paymentMode,
             LocalDate requestedStartDate) {
         var requestedEndDate = paymentRequest.getEndDate();
+        log.debug(
+                "resolveRequestedOrCalculatedEndDate called with paymentRequest={}, paymentType={}, paymentMode={}, requestedStartDate={}, requestedEndDate={}",
+                paymentRequest, paymentType, paymentMode, requestedStartDate, requestedEndDate);
 
         // Preserve explicitly provided historical ranges used by integrations/imports.
         if (paymentRequest.getStartDate() != null
                 && requestedEndDate != null
                 && !requestedEndDate.isAfter(LocalDate.now())) {
+            log.debug("resolveRequestedOrCalculatedEndDate preserving requested historical end date {}", requestedEndDate);
             return requestedEndDate;
         }
 
-        return calculateEndDateForMode(paymentType, paymentMode, requestedStartDate);
+        var calculatedEndDate = calculateEndDateForMode(paymentType, paymentMode, requestedStartDate);
+        log.debug("resolveRequestedOrCalculatedEndDate calculated end date {}", calculatedEndDate);
+        return calculatedEndDate;
     }
 
     private PeriodicPaymentTypeEnum normalizePeriodicType(String type) {

--- a/service/src/main/java/io/oxalate/backend/tools/PeriodTools.java
+++ b/service/src/main/java/io/oxalate/backend/tools/PeriodTools.java
@@ -6,9 +6,14 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.IsoFields;
 import java.time.temporal.TemporalAdjusters;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class PeriodTools {
     public static PeriodResult calculatePeriod(LocalDate currentDate, LocalDate startDate, ChronoUnit calendarUnit, long periodStart, long unitCount) {
+        log.debug("calculatePeriod called with currentDate={}, startDate={}, calendarUnit={}, periodStart={}, unitCount={}",
+                currentDate, startDate, calendarUnit, periodStart, unitCount);
+
         // Ensure valid input for the period start
         if (periodStart <= 0 || periodStart > getMaxUnitValue(calendarUnit)) {
             throw new IllegalArgumentException("Invalid period start value for the given calendar unit.");
@@ -20,19 +25,30 @@ public class PeriodTools {
 
         // Align the first period's start date
         var periodStartDate = alignFirstPeriodStart(startDate, calendarUnit, (int) periodStart);
+        log.debug("Aligned initial period start date to {}", periodStartDate);
 
         // Move backwards when querying dates earlier than the configured anchor to avoid forward overflow.
+        var backwardsIterations = 0;
         while (currentDate.isBefore(periodStartDate)) {
+            var previousPeriodStartDate = periodStartDate;
             periodStartDate = periodStartDate.minus(unitCount, calendarUnit);
+            backwardsIterations++;
+            log.debug("Moved period start backwards from {} to {} (iteration={})", previousPeriodStartDate, periodStartDate, backwardsIterations);
         }
 
         // Iterate forward in unitCount increments to find the matching period.
+        var forwardIterations = 0;
         while (!isDateWithinPeriod(currentDate, periodStartDate, calendarUnit, (int) unitCount)) {
+            var previousPeriodStartDate = periodStartDate;
             periodStartDate = periodStartDate.plus(unitCount, calendarUnit);
+            forwardIterations++;
+            log.debug("Moved period start forward from {} to {} (iteration={})", previousPeriodStartDate, periodStartDate, forwardIterations);
         }
 
         // Calculate the end date of the identified period
         var periodEndDate = calculatePeriodEnd(periodStartDate, calendarUnit, (int) unitCount);
+        log.debug("Resolved period result startDate={}, endDate={}, backwardsIterations={}, forwardIterations={}",
+                periodStartDate, periodEndDate, backwardsIterations, forwardIterations);
 
         return PeriodResult.builder()
                            .startDate(periodStartDate)
@@ -41,7 +57,7 @@ public class PeriodTools {
     }
 
     private static LocalDate alignFirstPeriodStart(LocalDate startDate, ChronoUnit unit, int periodStart) {
-        return switch (unit) {
+        var alignedDate = switch (unit) {
             case YEARS, MONTHS -> startDate.withMonth(periodStart)
                                            .withDayOfMonth(1);
             case WEEKS ->
@@ -52,15 +68,27 @@ public class PeriodTools {
             case DAYS -> startDate;
             default -> throw new IllegalArgumentException("Unsupported calendar unit: " + unit);
         };
+
+        log.debug("alignFirstPeriodStart resolved startDate={}, unit={}, periodStart={} to alignedDate={}",
+                startDate, unit, periodStart, alignedDate);
+
+        return alignedDate;
     }
 
     private static boolean isDateWithinPeriod(LocalDate date, LocalDate periodStart, ChronoUnit unit, int unitCount) {
         var periodEnd = calculatePeriodEnd(periodStart, unit, unitCount);
-        return (date.isEqual(periodStart) || date.isAfter(periodStart)) && date.isBefore(periodEnd.plusDays(1));
+        // Use an exclusive end boundary so exact boundary dates belong to the next period.
+        var withinPeriod = (date.isEqual(periodStart) || date.isAfter(periodStart)) && date.isBefore(periodEnd);
+        log.debug("isDateWithinPeriod evaluated date={}, periodStart={}, periodEnd={}, unit={}, unitCount={}, withinPeriod={}",
+                date, periodStart, periodEnd, unit, unitCount, withinPeriod);
+        return withinPeriod;
     }
 
     private static LocalDate calculatePeriodEnd(LocalDate periodStart, ChronoUnit unit, int unitCount) {
-        return periodStart.plus(unitCount, unit);
+        var periodEnd = periodStart.plus(unitCount, unit);
+        log.debug("calculatePeriodEnd resolved periodStart={}, unit={}, unitCount={} to periodEnd={}",
+                periodStart, unit, unitCount, periodEnd);
+        return periodEnd;
     }
 
     private static int getMaxUnitValue(ChronoUnit unit) {

--- a/service/src/test/java/io/oxalate/backend/tools/PeriodToolsUTC.java
+++ b/service/src/test/java/io/oxalate/backend/tools/PeriodToolsUTC.java
@@ -44,4 +44,15 @@ public class PeriodToolsUTC {
         assertEquals(LocalDate.of(currentYear + 5, 1, 1), periodResult.getStartDate());
         assertEquals(LocalDate.of(currentYear + 6, 1, 1), periodResult.getEndDate());
     }
+
+    @Test
+    void periodBoundaryDateBelongsToNextPeriodOk() {
+        var currentDate = LocalDate.of(2026, 1, 1);
+        var anchorDate = LocalDate.of(2025, 3, 3);
+
+        var periodResult = PeriodTools.calculatePeriod(currentDate, anchorDate, ChronoUnit.YEARS, 1, 1);
+
+        assertEquals(LocalDate.of(2026, 1, 1), periodResult.getStartDate());
+        assertEquals(LocalDate.of(2027, 1, 1), periodResult.getEndDate());
+    }
 }


### PR DESCRIPTION
This pull request adds detailed debug-level logging throughout the payment processing and period calculation logic to improve traceability and troubleshooting. It also introduces a new test to verify correct period boundary behavior. The most important changes are grouped below:

**Enhanced Logging for Payment Processing:**

* Added debug logs in `PaymentService.java` methods (`saveOneTimePayment`, `savePeriodPayment`) to trace incoming requests, resolved dates, and persisted payment entities. [[1]](diffhunk://#diff-06ca10a1418e957e49fe525c5fb0854db9037b3216c4a163992e277cd19ce08bR176) [[2]](diffhunk://#diff-06ca10a1418e957e49fe525c5fb0854db9037b3216c4a163992e277cd19ce08bR247) [[3]](diffhunk://#diff-06ca10a1418e957e49fe525c5fb0854db9037b3216c4a163992e277cd19ce08bR272) [[4]](diffhunk://#diff-06ca10a1418e957e49fe525c5fb0854db9037b3216c4a163992e277cd19ce08bR289) [[5]](diffhunk://#diff-06ca10a1418e957e49fe525c5fb0854db9037b3216c4a163992e277cd19ce08bR298) [[6]](diffhunk://#diff-06ca10a1418e957e49fe525c5fb0854db9037b3216c4a163992e277cd19ce08bR336)
* Improved logging in the `getEffectivePaymentMode`, `calculateEndDateForMode`, and `resolveRequestedOrCalculatedEndDate` methods to capture configuration values, resolution logic, and decision points. [[1]](diffhunk://#diff-06ca10a1418e957e49fe525c5fb0854db9037b3216c4a163992e277cd19ce08bL420-R453) [[2]](diffhunk://#diff-06ca10a1418e957e49fe525c5fb0854db9037b3216c4a163992e277cd19ce08bL465-R508)

**Comprehensive Logging in Period Calculation Utilities:**

* Introduced extensive debug logs in `PeriodTools.java` to trace period alignment, iteration steps, period boundary checks, and calculated results. [[1]](diffhunk://#diff-f5e4d9e0e7f9815b7a8bed1f3869a4cfe41155691ba74bfc82ebb8aadab2a040R9-R16) [[2]](diffhunk://#diff-f5e4d9e0e7f9815b7a8bed1f3869a4cfe41155691ba74bfc82ebb8aadab2a040R28-R51) [[3]](diffhunk://#diff-f5e4d9e0e7f9815b7a8bed1f3869a4cfe41155691ba74bfc82ebb8aadab2a040L44-R60) [[4]](diffhunk://#diff-f5e4d9e0e7f9815b7a8bed1f3869a4cfe41155691ba74bfc82ebb8aadab2a040R71-R91)
* Updated period boundary logic to use an exclusive end boundary, ensuring that exact boundary dates belong to the next period, and added corresponding logging.

**Testing Improvements:**

* Added a new unit test `periodBoundaryDateBelongsToNextPeriodOk` in `PeriodToolsUTC.java` to verify that period boundaries are handled as expected (boundary dates start the next period).