### PR TITLE
Allow user to change the email address/username

### DIFF
--- a/api/src/main/java/io/oxalate/backend/api/request/EmailChangeRequest.java
+++ b/api/src/main/java/io/oxalate/backend/api/request/EmailChangeRequest.java
@@ -1,0 +1,32 @@
+package io.oxalate.backend.api.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "Email change request")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailChangeRequest {
+    @NotBlank
+    @Size(max = 80)
+    @Email
+    @Schema(description = "New email address", example = "new.email@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("newEmail")
+    private String newEmail;
+
+    @NotBlank
+    @Size(min = 6, max = 120)
+    @Schema(description = "Current password for authorization", example = "Avery^S3curePasswd", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("password")
+    private String password;
+}
+

--- a/api/src/main/java/io/oxalate/backend/rest/AuthAPI.java
+++ b/api/src/main/java/io/oxalate/backend/rest/AuthAPI.java
@@ -2,6 +2,7 @@ package io.oxalate.backend.rest;
 
 import static io.oxalate.backend.api.SecurityConstants.JWT_COOKIE;
 import static io.oxalate.backend.api.UrlConstants.API;
+import io.oxalate.backend.api.request.EmailChangeRequest;
 import io.oxalate.backend.api.request.EmailRequest;
 import io.oxalate.backend.api.request.LoginRequest;
 import io.oxalate.backend.api.request.SignupRequest;
@@ -114,4 +115,23 @@ public interface AuthAPI {
     })
     @PostMapping(path = BASE_PATH + "/reset-password")
     ResponseEntity<ActionResponse> resetPassword(@RequestBody UserResetPasswordRequest userResetPasswordRequest, HttpServletRequest request);
+
+    @Operation(description = "Authenticated endpoint to request email-address change", tags = "AuthAPI")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "EmailChangeRequest", required = true)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Validation and request handling completed. Returns true only when request was accepted."),
+            @ApiResponse(responseCode = "403", description = "Not authorized")
+    })
+    @SecurityRequirement(name = JWT_COOKIE)
+    @PostMapping(path = BASE_PATH + "/email-change/requests", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<Boolean> requestEmailChange(@Valid @RequestBody EmailChangeRequest emailChangeRequest, HttpServletRequest request,
+            HttpServletResponse response);
+
+    @Operation(description = "Endpoint used in the email change confirmation link", tags = "AuthAPI")
+    @Parameter(name = "token", description = "Email change token", required = true)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "302", description = "Redirect to frontend page with status query parameter")
+    })
+    @GetMapping(path = BASE_PATH + "/email-change/confirmations")
+    ResponseEntity<Void> verifyEmailChange(@RequestParam(name = "token") String token, HttpServletRequest request, HttpServletResponse response);
 }

--- a/service/src/main/java/io/oxalate/backend/controller/AuthController.java
+++ b/service/src/main/java/io/oxalate/backend/controller/AuthController.java
@@ -1,6 +1,7 @@
 package io.oxalate.backend.controller;
 
 import static io.oxalate.backend.api.SecurityConstants.JWT_TOKEN;
+import io.oxalate.backend.api.request.EmailChangeRequest;
 import io.oxalate.backend.api.request.EmailRequest;
 import io.oxalate.backend.api.request.LoginRequest;
 import io.oxalate.backend.api.request.SignupRequest;
@@ -15,6 +16,10 @@ import io.oxalate.backend.audit.AuditSource;
 import io.oxalate.backend.audit.Audited;
 import static io.oxalate.backend.events.AppAuditMessages.AUTH_AUTHENTICATION_OK;
 import static io.oxalate.backend.events.AppAuditMessages.AUTH_AUTHENTICATION_START;
+import static io.oxalate.backend.events.AppAuditMessages.AUTH_EMAIL_CHANGE_REQUEST_OK;
+import static io.oxalate.backend.events.AppAuditMessages.AUTH_EMAIL_CHANGE_REQUEST_START;
+import static io.oxalate.backend.events.AppAuditMessages.AUTH_EMAIL_CHANGE_VERIFY_OK;
+import static io.oxalate.backend.events.AppAuditMessages.AUTH_EMAIL_CHANGE_VERIFY_START;
 import static io.oxalate.backend.events.AppAuditMessages.AUTH_LOGOUT_OK;
 import static io.oxalate.backend.events.AppAuditMessages.AUTH_LOGOUT_START;
 import static io.oxalate.backend.events.AppAuditMessages.AUTH_LOST_PASSWORD_START;
@@ -97,9 +102,27 @@ public class AuthController implements AuthAPI {
     }
 
     @Override
+    @PreAuthorize("hasAnyRole('USER', 'ORGANIZER', 'ADMIN')")
+    @Audited(startMessage = AUTH_EMAIL_CHANGE_REQUEST_START, okMessage = AUTH_EMAIL_CHANGE_REQUEST_OK)
+    public ResponseEntity<Boolean> requestEmailChange(EmailChangeRequest emailChangeRequest, HttpServletRequest request, HttpServletResponse response) {
+        var userId = AuthTools.getCurrentUserId();
+        var changeRequested = authService.requestEmailChange(userId, emailChangeRequest, request, response);
+        return ResponseEntity.ok(changeRequested);
+    }
+
+    @Override
     @Audited(startMessage = AUTH_REGISTRATION_VERIFY_START, okMessage = AUTH_REGISTRATION_VERIFY_OK)
     public ResponseEntity<Void> verifyRegistration(String token, HttpServletRequest request) {
         var uri = authService.verifyRegistration(token, request);
+        return ResponseEntity.status(301)
+                             .location(uri)
+                             .build();
+    }
+
+    @Override
+    @Audited(startMessage = AUTH_EMAIL_CHANGE_VERIFY_START, okMessage = AUTH_EMAIL_CHANGE_VERIFY_OK)
+    public ResponseEntity<Void> verifyEmailChange(String token, HttpServletRequest request, HttpServletResponse response) {
+        var uri = authService.verifyEmailChange(token, request, response);
         return ResponseEntity.status(301)
                              .location(uri)
                              .build();

--- a/service/src/main/java/io/oxalate/backend/events/AppAuditMessages.java
+++ b/service/src/main/java/io/oxalate/backend/events/AppAuditMessages.java
@@ -50,6 +50,15 @@ public class AppAuditMessages {
     public static final String AUTH_RESET_PASSWORD_UNKNOWN_ERROR = "User password failed for unknown reason";
     public static final String AUTH_RESET_PASSWORD_OK = "User password updated";
 
+    public static final String AUTH_EMAIL_CHANGE_REQUEST_START = "Email change requested";
+    public static final String AUTH_EMAIL_CHANGE_REQUEST_OK = "Email change request accepted";
+    public static final String AUTH_EMAIL_CHANGE_REQUEST_FAIL = "Email change request rejected";
+    public static final String AUTH_EMAIL_CHANGE_REQUEST_LOCKED = "Email change request max attempts reached and account locked";
+    public static final String AUTH_EMAIL_CHANGE_VERIFY_START = "Verifying email change token";
+    public static final String AUTH_EMAIL_CHANGE_VERIFY_OK = "Email address changed successfully";
+    public static final String AUTH_EMAIL_CHANGE_VERIFY_INVALID_TOKEN = "Email change token invalid or expired";
+    public static final String AUTH_EMAIL_CHANGE_VERIFY_INVALID_EMAIL = "Email change token payload email invalid";
+
     // BlockedDateController
     public static final String BLOCKED_DATE_GET_ALL_START = "Getting all blocked dates";
     public static final String BLOCKED_DATE_GET_ALL_UNAUTHORIZED = "User not authorized to get list of blocked dates";

--- a/service/src/main/java/io/oxalate/backend/model/Token.java
+++ b/service/src/main/java/io/oxalate/backend/model/Token.java
@@ -41,6 +41,9 @@ public class Token {
     @Column(name = "retry_count", nullable = false)
     private int retryCount;
 
+    @Column(name = "data")
+    private String data;
+
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 

--- a/service/src/main/java/io/oxalate/backend/model/TokenType.java
+++ b/service/src/main/java/io/oxalate/backend/model/TokenType.java
@@ -3,5 +3,6 @@ package io.oxalate.backend.model;
 public enum TokenType {
     REGISTRATION,
     EMAIL_RESEND,
-    PASSWORD_RESET
+    PASSWORD_RESET,
+    EMAIL_CHANGE
 }

--- a/service/src/main/java/io/oxalate/backend/repository/TokenRepository.java
+++ b/service/src/main/java/io/oxalate/backend/repository/TokenRepository.java
@@ -21,5 +21,8 @@ public interface TokenRepository extends CrudRepository<Token, Long> {
     @Modifying
     void deleteByUserId(long userId);
 
+    @Modifying
+    void deleteByUserIdAndTokenType(long userId, TokenType tokenType);
+
     Optional<Token> findByUserIdAndTokenType(long userId, TokenType tokenType);
 }

--- a/service/src/main/java/io/oxalate/backend/security/LoginAttemptService.java
+++ b/service/src/main/java/io/oxalate/backend/security/LoginAttemptService.java
@@ -45,10 +45,26 @@ public class LoginAttemptService {
     }
 
     public boolean isBlocked() {
+        return isBlocked(getRemoteIp(request));
+    }
+
+    public boolean isBlocked(String key) {
         try {
-            return attemptsCache.get(getRemoteIp(request)) >= MAX_ATTEMPT;
+            return attemptsCache.get(key) >= MAX_ATTEMPT;
         } catch (final ExecutionException e) {
             return false;
         }
+    }
+
+    public int getAttempts(String key) {
+        try {
+            return attemptsCache.get(key);
+        } catch (final ExecutionException e) {
+            return 0;
+        }
+    }
+
+    public void resetAttempts(String key) {
+        attemptsCache.invalidate(key);
     }
 }

--- a/service/src/main/java/io/oxalate/backend/service/AuthService.java
+++ b/service/src/main/java/io/oxalate/backend/service/AuthService.java
@@ -1,5 +1,8 @@
 package io.oxalate.backend.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import static io.oxalate.backend.api.AuditLevelEnum.ERROR;
 import static io.oxalate.backend.api.AuditLevelEnum.INFO;
 import static io.oxalate.backend.api.AuditLevelEnum.WARN;
@@ -8,6 +11,7 @@ import io.oxalate.backend.api.UpdateStatusEnum;
 import static io.oxalate.backend.api.UserStatusEnum.ACTIVE;
 import static io.oxalate.backend.api.UserStatusEnum.LOCKED;
 import static io.oxalate.backend.api.UserStatusEnum.REGISTERED;
+import io.oxalate.backend.api.request.EmailChangeRequest;
 import io.oxalate.backend.api.request.EmailRequest;
 import io.oxalate.backend.api.request.LoginRequest;
 import io.oxalate.backend.api.request.SignupRequest;
@@ -22,6 +26,12 @@ import io.oxalate.backend.api.response.UserUpdateStatus;
 import io.oxalate.backend.audit.AuditContext;
 import static io.oxalate.backend.events.AppAuditMessages.AUTH_AUTHENTICATION_FAIL;
 import static io.oxalate.backend.events.AppAuditMessages.AUTH_AUTHENTICATION_NO_ROLES;
+import static io.oxalate.backend.events.AppAuditMessages.AUTH_EMAIL_CHANGE_REQUEST_FAIL;
+import static io.oxalate.backend.events.AppAuditMessages.AUTH_EMAIL_CHANGE_REQUEST_LOCKED;
+import static io.oxalate.backend.events.AppAuditMessages.AUTH_EMAIL_CHANGE_REQUEST_OK;
+import static io.oxalate.backend.events.AppAuditMessages.AUTH_EMAIL_CHANGE_VERIFY_INVALID_EMAIL;
+import static io.oxalate.backend.events.AppAuditMessages.AUTH_EMAIL_CHANGE_VERIFY_INVALID_TOKEN;
+import static io.oxalate.backend.events.AppAuditMessages.AUTH_EMAIL_CHANGE_VERIFY_OK;
 import static io.oxalate.backend.events.AppAuditMessages.AUTH_LOST_PASSWORD_FAIL;
 import static io.oxalate.backend.events.AppAuditMessages.AUTH_LOST_PASSWORD_INACTIVE_STATUS;
 import static io.oxalate.backend.events.AppAuditMessages.AUTH_LOST_PASSWORD_OK;
@@ -48,10 +58,12 @@ import static io.oxalate.backend.events.AppAuditMessages.AUTH_UPDATE_PASSWORD_OL
 import static io.oxalate.backend.events.AppAuditMessages.AUTH_UPDATE_PASSWORD_UNAUTHORIZED;
 import io.oxalate.backend.events.AppEventPublisher;
 import io.oxalate.backend.exception.OxalateAuthenticationException;
+import static io.oxalate.backend.model.TokenType.EMAIL_CHANGE;
 import static io.oxalate.backend.model.TokenType.EMAIL_RESEND;
 import static io.oxalate.backend.model.TokenType.PASSWORD_RESET;
 import static io.oxalate.backend.model.TokenType.REGISTRATION;
 import io.oxalate.backend.model.User;
+import io.oxalate.backend.security.LoginAttemptService;
 import io.oxalate.backend.security.jwt.JwtUtils;
 import io.oxalate.backend.security.service.UserDetailsImpl;
 import jakarta.servlet.http.HttpServletRequest;
@@ -60,7 +72,10 @@ import java.net.URI;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -93,6 +108,9 @@ public class AuthService {
     private final RegistrationService registrationService;
     private final EmailService emailService;
     private final JwtUtils jwtUtils;
+    private final LoginAttemptService loginAttemptService;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String EMAIL_CHANGE_ATTEMPT_KEY_PREFIX = "email-change:";
 
     @Value("${oxalate.app.jwt-expiration}")
     private int expirationTime;
@@ -102,6 +120,8 @@ public class AuthService {
     private String sameSite;
     @Value("${oxalate.token.registration-url}")
     private String registrationUrl;
+    @Value("${oxalate.token.email-change-url}")
+    private String emailChangeUrl;
 
     @Transactional(readOnly = true)
     public UserSessionToken authenticate(LoginRequest loginRequest, HttpServletRequest request, HttpServletResponse response) {
@@ -506,6 +526,81 @@ public class AuthService {
                                    .build();
     }
 
+    @Transactional
+    public boolean requestEmailChange(long userId, EmailChangeRequest emailChangeRequest, HttpServletRequest request, HttpServletResponse response) {
+        var auditUuid = AuditContext.getTraceId();
+        var user = userService.findUserEntityById(userId);
+
+        if (user == null || user.getStatus() != ACTIVE) {
+            return false;
+        }
+
+        var attemptKey = EMAIL_CHANGE_ATTEMPT_KEY_PREFIX + userId;
+        if (loginAttemptService.isBlocked(attemptKey)) {
+            lockUserAndInvalidateSession(userId, request, auditUuid, response);
+            return false;
+        }
+
+        var normalizedEmail = emailChangeRequest.getNewEmail()
+                                                .trim()
+                                                .toLowerCase(Locale.ROOT);
+        var emailValid = userService.isUsernameAvailableForUser(normalizedEmail, userId) &&
+                !normalizedEmail.equals(user.getUsername());
+        var passwordValid = validateCurrentPassword(user.getUsername(), emailChangeRequest.getPassword());
+
+        if (!emailValid || !passwordValid) {
+            loginAttemptService.loginFailed(attemptKey);
+            var attempts = loginAttemptService.getAttempts(attemptKey);
+            appEventPublisher.publishAuditEvent(AUTH_EMAIL_CHANGE_REQUEST_FAIL + " userId=" + userId + " attempts=" + attempts,
+                    WARN, request, AUDIT_NAME, userId, auditUuid);
+
+            if (attempts >= LoginAttemptService.MAX_ATTEMPT) {
+                lockUserAndInvalidateSession(userId, request, auditUuid, response);
+            }
+            return false;
+        }
+
+        loginAttemptService.resetAttempts(attemptKey);
+        registrationService.removeTokenByUserIdAndType(userId, EMAIL_CHANGE);
+        var tokenPayload = createEmailChangeTokenPayload(normalizedEmail);
+        var token = registrationService.generateToken(userId, EMAIL_CHANGE, tokenPayload);
+        emailService.sendEmailChangeConfirmationEmail(user, normalizedEmail, token);
+        appEventPublisher.publishAuditEvent(AUTH_EMAIL_CHANGE_REQUEST_OK + " userId=" + userId, INFO, request, AUDIT_NAME, userId, auditUuid);
+        return true;
+    }
+
+    @Transactional
+    public URI verifyEmailChange(String tokenString, HttpServletRequest request, HttpServletResponse response) {
+        var auditUuid = AuditContext.getTraceId();
+        var token = registrationService.getValidToken(tokenString, EMAIL_CHANGE);
+        var returnStatus = "OK";
+
+        if (token == null) {
+            appEventPublisher.publishAuditEvent(AUTH_EMAIL_CHANGE_VERIFY_INVALID_TOKEN, WARN, request, AUDIT_NAME, null, auditUuid);
+            returnStatus = "INVALID";
+            return buildEmailChangeRedirectUri(returnStatus);
+        }
+
+        var pendingEmail = parsePendingEmail(token.getData());
+        if (pendingEmail == null || !userService.isUsernameAvailableForUser(pendingEmail, token.getUserId())) {
+            appEventPublisher.publishAuditEvent(AUTH_EMAIL_CHANGE_VERIFY_INVALID_EMAIL, WARN, request, AUDIT_NAME, token.getUserId(), auditUuid);
+            registrationService.removeTokenByUserIdAndType(token.getUserId(), EMAIL_CHANGE);
+            returnStatus = "INVALID";
+            return buildEmailChangeRedirectUri(returnStatus);
+        }
+
+        if (!userService.updateUsername(token.getUserId(), pendingEmail)) {
+            returnStatus = "INVALID";
+            return buildEmailChangeRedirectUri(returnStatus);
+        }
+
+        registrationService.removeTokenByUserIdAndType(token.getUserId(), EMAIL_CHANGE);
+        clearJwtCookie(response);
+        SecurityContextHolder.clearContext();
+        appEventPublisher.publishAuditEvent(AUTH_EMAIL_CHANGE_VERIFY_OK, INFO, request, AUDIT_NAME, token.getUserId(), auditUuid);
+        return buildEmailChangeRedirectUri(returnStatus);
+    }
+
     public URI verifyRegistration(String token, HttpServletRequest request) {
         var auditUuid = AuditContext.getTraceId();
         var registrationToken = registrationService.getValidToken(token, REGISTRATION);
@@ -525,5 +620,71 @@ public class AuthService {
                                    .query("status={returnStatus}")
                                    .buildAndExpand(returnStatus)
                                    .toUri();
+    }
+
+    private boolean validateCurrentPassword(String username, String password) {
+        try {
+            authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(username, password));
+            return true;
+        } catch (AuthenticationException e) {
+            return false;
+        }
+    }
+
+    private String createEmailChangeTokenPayload(String newEmail) {
+        Map<String, String> payload = new HashMap<>();
+        payload.put("newEmail", newEmail);
+
+        try {
+            return OBJECT_MAPPER.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to create email-change token payload", e);
+            return null;
+        }
+    }
+
+    private String parsePendingEmail(String tokenData) {
+        if (tokenData == null || tokenData.isBlank()) {
+            return null;
+        }
+
+        try {
+            Map<String, String> payload = OBJECT_MAPPER.readValue(tokenData, new TypeReference<>() {
+            });
+            var email = payload.get("newEmail");
+            return email == null ?
+                    null :
+                    email.trim()
+                         .toLowerCase(Locale.ROOT);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to parse email-change token payload", e);
+            return null;
+        }
+    }
+
+    private URI buildEmailChangeRedirectUri(String returnStatus) {
+        return UriComponentsBuilder.fromUriString(emailChangeUrl)
+                                   .query("status={returnStatus}")
+                                   .buildAndExpand(returnStatus)
+                                   .toUri();
+    }
+
+    private void lockUserAndInvalidateSession(long userId, HttpServletRequest request, java.util.UUID auditUuid, HttpServletResponse response) {
+        userService.updateStatus(userId, LOCKED);
+        clearJwtCookie(response);
+        SecurityContextHolder.clearContext();
+        appEventPublisher.publishAuditEvent(AUTH_EMAIL_CHANGE_REQUEST_LOCKED + " userId=" + userId, WARN, request, AUDIT_NAME, userId, auditUuid);
+    }
+
+    private void clearJwtCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(JWT_TOKEN, "")
+                                              .httpOnly(true)
+                                              .secure(secureCookie)
+                                              .path("/")
+                                              .maxAge(0)
+                                              .sameSite(sameSite)
+                                              .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 }

--- a/service/src/main/java/io/oxalate/backend/service/EmailService.java
+++ b/service/src/main/java/io/oxalate/backend/service/EmailService.java
@@ -56,6 +56,9 @@ public class EmailService {
     @Value("${oxalate.token.lost-password-url}")
     private String lostPasswordUrl;
 
+    @Value("${oxalate.token.email-change-confirmation-url}")
+    private String emailChangeConfirmationUrl;
+
     @Value("${oxalate.app.frontend-url}")
     private String frontendUrl;
 
@@ -103,6 +106,30 @@ public class EmailService {
         }
 
         return false;
+    }
+
+    public void sendEmailChangeConfirmationEmail(User user, String newEmail, String token) {
+        var confirmationUrlWithToken = emailChangeConfirmationUrl + "?token=" + token;
+        var userLanguage =
+                user.getLanguage() != null ? user.getLanguage() : portalConfigurationService.getStringConfiguration(GENERAL.group, DEFAULT_LANGUAGE.key);
+        var locale = Locale.forLanguageTag(userLanguage);
+        var organizationName = portalConfigurationService.getStringConfiguration(GENERAL.group, ORG_NAME.key);
+        var subject = messageSource.getMessage("email.email-change.subject", new Object[] { organizationName }, locale);
+
+        Context context = new Context(locale);
+        context.setVariable("name", user.getFirstName());
+        context.setVariable("url", confirmationUrlWithToken);
+        context.setVariable("newEmail", newEmail);
+        context.setVariable("supportEmail", portalConfigurationService.getStringConfiguration(EMAIL.group, SUPPORT_EMAIL.key));
+        context.setVariable("orgName", organizationName);
+        context.setVariable("tokenTtl", tokenTtl);
+        String body = templateEngine.process("emailChangeTemplate_" + locale.getLanguage(), context);
+
+        try {
+            sendHtmlMail(portalConfigurationService.getStringConfiguration(EMAIL.group, SYSTEM_EMAIL.key), newEmail, subject, body);
+        } catch (MailException e) {
+            log.error("Sending email change confirmation failed: ", e);
+        }
     }
 
     public void sendEventNotificationEmail(String emailAddress, String language, EmailNotificationDetailEnum detail, Event event) {

--- a/service/src/main/java/io/oxalate/backend/service/RegistrationService.java
+++ b/service/src/main/java/io/oxalate/backend/service/RegistrationService.java
@@ -30,11 +30,17 @@ public class RegistrationService {
 
     @Transactional
     public String generateToken(long userId, TokenType tokenType) {
+        return generateToken(userId, tokenType, null);
+    }
+
+    @Transactional
+    public String generateToken(long userId, TokenType tokenType, String data) {
         var token = Hashing.sha256().hashString(UUID.randomUUID().toString(), UTF_8).toString();
         var registrationToken = Token.builder()
                 .token(token)
                 .tokenType(tokenType)
                 .userId(userId)
+                                     .data(data)
                 .createdAt(Instant.now())
                 .expiresAt(Instant.now().plusSeconds(60 * 60 * tokenExpiresAfter))
                 .build();
@@ -52,6 +58,11 @@ public class RegistrationService {
     @Transactional
     public void removeTokenByUserId(long userId) {
         tokenRepository.deleteByUserId(userId);
+    }
+
+    @Transactional
+    public void removeTokenByUserIdAndType(long userId, TokenType tokenType) {
+        tokenRepository.deleteByUserIdAndTokenType(userId, tokenType);
     }
 
     /**

--- a/service/src/main/java/io/oxalate/backend/service/UserService.java
+++ b/service/src/main/java/io/oxalate/backend/service/UserService.java
@@ -16,6 +16,8 @@ import io.oxalate.backend.repository.MembershipRepository;
 import io.oxalate.backend.repository.RoleRepository;
 import io.oxalate.backend.repository.UserRepository;
 import io.oxalate.backend.service.filetransfer.AvatarFileTransferService;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -290,6 +292,47 @@ public class UserService {
     public boolean isUsernameValid(String username) {
         return findByUsername(username).isEmpty() &&
                 !username.contains("%");
+    }
+
+    public boolean isEmailAddressFormatValid(String username) {
+        if (username == null || username.isBlank() || username.contains("%")) {
+            return false;
+        }
+
+        try {
+            var internetAddress = new InternetAddress(username);
+            internetAddress.validate();
+            return true;
+        } catch (AddressException e) {
+            return false;
+        }
+    }
+
+    public boolean isUsernameAvailableForUser(String username, long userId) {
+        if (!isEmailAddressFormatValid(username)) {
+            return false;
+        }
+
+        var normalizedUsername = username.trim()
+                                         .toLowerCase();
+        var optionalUser = findByUsername(normalizedUsername);
+
+        return optionalUser.isEmpty();
+    }
+
+    @Transactional
+    public boolean updateUsername(long userId, String newUsername) {
+        var optionalUser = userRepository.findById(userId);
+
+        if (optionalUser.isEmpty()) {
+            return false;
+        }
+
+        var user = optionalUser.get();
+        user.setUsername(newUsername.trim()
+                                    .toLowerCase());
+        userRepository.save(user);
+        return true;
     }
 
     @Transactional

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -99,6 +99,8 @@ oxalate:
     maxRetryCount: 3
     registration-url: ${oxalate.app.frontend-url}/registration
     confirmation-url: ${oxalate.app.backend-url}/api/auth/registrations
+    email-change-confirmation-url: ${oxalate.app.backend-url}/api/auth/email-change/confirmations
+    email-change-url: ${oxalate.app.frontend-url}/auth/email-change
     lost-password-url: ${oxalate.app.frontend-url}/auth/new-password
   audit:
     retention:

--- a/service/src/main/resources/db/migration/V36__add_data_to_tokens.sql
+++ b/service/src/main/resources/db/migration/V36__add_data_to_tokens.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tokens
+    ADD COLUMN data TEXT;
+

--- a/service/src/main/resources/messages.properties
+++ b/service/src/main/resources/messages.properties
@@ -1,4 +1,5 @@
 email.confirmation.subject=Welcome to {0} portal
+email.email-change.subject=Confirm your new email address for {0}
 email.forgotten-password.subject=Forgotten password
 email.notification.new-page.subject=A new page has been created
 email.notification.updated-page.subject=A page has been updated

--- a/service/src/main/resources/messages_de.properties
+++ b/service/src/main/resources/messages_de.properties
@@ -1,4 +1,5 @@
 email.confirmation.subject=Willkommen zu {0} portal
+email.email-change.subject=Bestaetigen Sie Ihre neue E-Mail-Adresse fuer {0}
 email.forgotten-password.subject=Passwort vergessen
 email.notification.new-page.subject=Eine neue Seite wurde erstellt
 email.notification.updated-page.subject=Eine Seite wurde aktualisiert

--- a/service/src/main/resources/messages_fi.properties
+++ b/service/src/main/resources/messages_fi.properties
@@ -1,4 +1,5 @@
 email.confirmation.subject=Tervetuloa {0}:n portaaliin
+email.email-change.subject=Vahvista uusi sahkopostiosoitteesi palvelussa {0}
 email.forgotten-password.subject=Unohtunut salasana
 email.notification.new-page.subject=Uusi sivu on luotu
 email.notification.updated-page.subject=Sivua on päivitetty

--- a/service/src/main/resources/messages_sv.properties
+++ b/service/src/main/resources/messages_sv.properties
@@ -1,4 +1,5 @@
 email.confirmation.subject=Välkommen till {0} portal
+email.email-change.subject=Bekrafta din nya e-postadress for {0}
 email.forgotten-password.subject=Glömd lösenord
 email.notification.new-page.subject=En ny sida har skapats
 email.notification.updated-page.subject=En sida har uppdaterats

--- a/service/src/main/resources/templates/emailChangeTemplate_de.html
+++ b/service/src/main/resources/templates/emailChangeTemplate_de.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="de">
+<head>
+    <title>E-Mail-Anderung fur [[${orgName}]] bestaetigen</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+<body>
+<p>Hallo <span th:text="${name}"></span>!</p>
+
+<p>Wir haben eine Anfrage erhalten, Ihre E-Mail-Adresse im [[${orgName}]]-Portal auf <strong th:text="${newEmail}"></strong> zu andern.</p>
+
+<p>Bitte bestaetigen Sie die Anderung durch Klick auf <a th:href="@{${url}}">diesen Link</a>.</p>
+
+<p>Der Link ist [[${tokenTtl}]] Stunden gueltig.</p>
+
+<p>Falls Sie diese Anderung nicht angefordert haben, ignorieren Sie diese E-Mail oder kontaktieren Sie [[${supportEmail}]].</p>
+
+<p>Viele Grusse, [[${orgName}]]</p>
+</body>
+</html>
+

--- a/service/src/main/resources/templates/emailChangeTemplate_en.html
+++ b/service/src/main/resources/templates/emailChangeTemplate_en.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <title>Confirm email change for [[${orgName}]]</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+<body>
+<p>Hello <span th:text="${name}"></span>!</p>
+
+<p>We received a request to change your email address in [[${orgName}]] Portal to <strong th:text="${newEmail}"></strong>.</p>
+
+<p>Confirm the change by clicking <a th:href="@{${url}}">here</a>.</p>
+
+<p>The link is valid for [[${tokenTtl}]] hours.</p>
+
+<p>If you did not request this change, please ignore this email or contact [[${supportEmail}]].</p>
+
+<p>Best regards, [[${orgName}]]</p>
+</body>
+</html>
+

--- a/service/src/main/resources/templates/emailChangeTemplate_fi.html
+++ b/service/src/main/resources/templates/emailChangeTemplate_fi.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="fi">
+<head>
+    <title>Vahvista sahkopostiosoitteen vaihto palvelussa [[${orgName}]]</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+<body>
+<p>Hei <span th:text="${name}"></span>!</p>
+
+<p>Saimme pyynnon vaihtaa [[${orgName}]]-portaalin sahkopostiosoitteesi osoitteeseen <strong th:text="${newEmail}"></strong>.</p>
+
+<p>Vahvista muutos klikkaamalla <a th:href="@{${url}}">tata linkkia</a>.</p>
+
+<p>Linkki on voimassa [[${tokenTtl}]] tuntia.</p>
+
+<p>Jos et pyytanyt muutosta, voit jattaa viestin huomiotta tai ottaa yhteytta osoitteeseen [[${supportEmail}]].</p>
+
+<p>Ystavaisin terveisin, [[${orgName}]]</p>
+</body>
+</html>
+

--- a/service/src/main/resources/templates/emailChangeTemplate_sv.html
+++ b/service/src/main/resources/templates/emailChangeTemplate_sv.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="sv">
+<head>
+    <title>Bekrafta e-postandring for [[${orgName}]]</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+<body>
+<p>Hej <span th:text="${name}"></span>!</p>
+
+<p>Vi har fatt en begaran om att byta din e-postadress i [[${orgName}]]-portalen till <strong th:text="${newEmail}"></strong>.</p>
+
+<p>Bekrafta andringen genom att klicka <a th:href="@{${url}}">har</a>.</p>
+
+<p>Lanken ar giltig i [[${tokenTtl}]] timmar.</p>
+
+<p>Om du inte begarde den har andringen kan du ignorera meddelandet eller kontakta [[${supportEmail}]].</p>
+
+<p>Vanliga halsningar, [[${orgName}]]</p>
+</body>
+</html>
+

--- a/service/src/test/java/io/oxalate/backend/service/AuthServiceUTC.java
+++ b/service/src/test/java/io/oxalate/backend/service/AuthServiceUTC.java
@@ -1,0 +1,209 @@
+package io.oxalate.backend.service;
+
+import static io.oxalate.backend.api.SecurityConstants.JWT_TOKEN;
+import static io.oxalate.backend.api.UserStatusEnum.ACTIVE;
+import static io.oxalate.backend.api.UserStatusEnum.LOCKED;
+import io.oxalate.backend.api.request.EmailChangeRequest;
+import io.oxalate.backend.events.AppEventPublisher;
+import io.oxalate.backend.model.Token;
+import static io.oxalate.backend.model.TokenType.EMAIL_CHANGE;
+import io.oxalate.backend.model.User;
+import io.oxalate.backend.security.LoginAttemptService;
+import io.oxalate.backend.security.jwt.JwtUtils;
+import java.net.URI;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceUTC {
+
+    @Mock
+    private AppEventPublisher appEventPublisher;
+    @Mock
+    private AuthenticationManager authenticationManager;
+    @Mock
+    private UserService userService;
+    @Mock
+    private RegistrationService registrationService;
+    @Mock
+    private EmailService emailService;
+    @Mock
+    private JwtUtils jwtUtils;
+    @Mock
+    private LoginAttemptService loginAttemptService;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(authService, "secureCookie", true);
+        ReflectionTestUtils.setField(authService, "sameSite", "Strict");
+        ReflectionTestUtils.setField(authService, "emailChangeUrl", "http://localhost:3000/auth/email-change");
+    }
+
+    @Test
+    void requestEmailChangeValidRequestOk() {
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var user = createActiveUser(100L, "current.user@example.com");
+        var emailChangeRequest = EmailChangeRequest.builder()
+                                                   .newEmail("new.user@example.com")
+                                                   .password("ValidPassword1!")
+                                                   .build();
+
+        when(userService.findUserEntityById(100L)).thenReturn(user);
+        when(loginAttemptService.isBlocked("email-change:100")).thenReturn(false);
+        when(userService.isUsernameAvailableForUser("new.user@example.com", 100L)).thenReturn(true);
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).thenReturn(org.mockito.Mockito.mock(Authentication.class));
+        when(registrationService.generateToken(eq(100L), eq(EMAIL_CHANGE), anyString())).thenReturn("token-value");
+
+        var result = authService.requestEmailChange(100L, emailChangeRequest, request, response);
+
+        assertTrue(result);
+        verify(registrationService).removeTokenByUserIdAndType(100L, EMAIL_CHANGE);
+        verify(loginAttemptService).resetAttempts("email-change:100");
+        verify(emailService).sendEmailChangeConfirmationEmail(user, "new.user@example.com", "token-value");
+    }
+
+    @Test
+    void requestEmailChangeInvalidPasswordFail() {
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var user = createActiveUser(100L, "current.user@example.com");
+        var emailChangeRequest = EmailChangeRequest.builder()
+                                                   .newEmail("new.user@example.com")
+                                                   .password("WrongPassword1!")
+                                                   .build();
+
+        when(userService.findUserEntityById(100L)).thenReturn(user);
+        when(loginAttemptService.isBlocked("email-change:100")).thenReturn(false);
+        when(userService.isUsernameAvailableForUser("new.user@example.com", 100L)).thenReturn(true);
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).thenThrow(new BadCredentialsException("bad password"));
+        when(loginAttemptService.getAttempts("email-change:100")).thenReturn(1);
+
+        var result = authService.requestEmailChange(100L, emailChangeRequest, request, response);
+
+        assertFalse(result);
+        verify(loginAttemptService).loginFailed("email-change:100");
+        verify(emailService, never()).sendEmailChangeConfirmationEmail(any(User.class), anyString(), anyString());
+    }
+
+    @Test
+    void requestEmailChangeMaxAttemptsLocksUser() {
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var user = createActiveUser(100L, "current.user@example.com");
+        var emailChangeRequest = EmailChangeRequest.builder()
+                                                   .newEmail("new.user@example.com")
+                                                   .password("WrongPassword1!")
+                                                   .build();
+
+        when(userService.findUserEntityById(100L)).thenReturn(user);
+        when(loginAttemptService.isBlocked("email-change:100")).thenReturn(false);
+        when(userService.isUsernameAvailableForUser("new.user@example.com", 100L)).thenReturn(true);
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).thenThrow(new BadCredentialsException("bad password"));
+        when(loginAttemptService.getAttempts("email-change:100")).thenReturn(LoginAttemptService.MAX_ATTEMPT);
+
+        var result = authService.requestEmailChange(100L, emailChangeRequest, request, response);
+
+        assertFalse(result);
+        verify(userService).updateStatus(100L, LOCKED);
+        assertNotNull(response.getHeader("Set-Cookie"));
+        assertTrue(response.getHeader("Set-Cookie")
+                           .contains(JWT_TOKEN + "="));
+    }
+
+    @Test
+    void verifyEmailChangeValidTokenOk() {
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var token = Token.builder()
+                         .token("token-value")
+                         .userId(100L)
+                         .tokenType(EMAIL_CHANGE)
+                         .data("{\"newEmail\":\"new.user@example.com\"}")
+                         .build();
+
+        when(registrationService.getValidToken("token-value", EMAIL_CHANGE)).thenReturn(token);
+        when(userService.isUsernameAvailableForUser("new.user@example.com", 100L)).thenReturn(true);
+        when(userService.updateUsername(100L, "new.user@example.com")).thenReturn(true);
+
+        URI uri = authService.verifyEmailChange("token-value", request, response);
+
+        assertEquals("http://localhost:3000/auth/email-change?status=OK", uri.toString());
+        verify(registrationService).removeTokenByUserIdAndType(100L, EMAIL_CHANGE);
+        assertNotNull(response.getHeader("Set-Cookie"));
+    }
+
+    @Test
+    void verifyEmailChangeInvalidTokenFail() {
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+
+        when(registrationService.getValidToken("missing-token", EMAIL_CHANGE)).thenReturn(null);
+
+        URI uri = authService.verifyEmailChange("missing-token", request, response);
+
+        assertEquals("http://localhost:3000/auth/email-change?status=INVALID", uri.toString());
+        verify(userService, never()).updateUsername(anyLong(), anyString());
+    }
+
+    @Test
+    void verifyEmailChangeInvalidPayloadFail() {
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var token = Token.builder()
+                         .token("token-value")
+                         .userId(100L)
+                         .tokenType(EMAIL_CHANGE)
+                         .data("{}")
+                         .build();
+
+        when(registrationService.getValidToken("token-value", EMAIL_CHANGE)).thenReturn(token);
+
+        URI uri = authService.verifyEmailChange("token-value", request, response);
+
+        assertEquals("http://localhost:3000/auth/email-change?status=INVALID", uri.toString());
+        verify(registrationService).removeTokenByUserIdAndType(100L, EMAIL_CHANGE);
+        verify(userService, never()).updateUsername(anyLong(), anyString());
+    }
+
+    private User createActiveUser(long id, String username) {
+        return User.builder()
+                   .id(id)
+                   .username(username)
+                   .firstName("Current")
+                   .lastName("User")
+                   .status(ACTIVE)
+                   .phoneNumber("358401234567")
+                   .privacy(false)
+                   .password("$2a$10$hash")
+                   .approvedTerms(true)
+                   .language("en")
+                   .build();
+    }
+}
+


### PR DESCRIPTION
This pull request introduces a new feature that allows authenticated users to request an email address change, including the supporting backend logic, validation, security, and audit logging. It also adds endpoints for confirming the email change via a tokenized link. The changes include updates to the API, controller, service layer, token management, and audit messages to support the new email change workflow.

**Email Change Request and Confirmation Feature:**

* Added a new `EmailChangeRequest` DTO with validation for the new email and current password.
* Introduced two new API endpoints in `AuthAPI`: one for requesting an email change (POST `/email-change/requests`) and one for confirming the change via a token (GET `/email-change/confirmations`).
* Implemented controller methods in `AuthController` to handle the new endpoints, including audit logging and authorization checks. [[1]](diffhunk://#diff-9207856edd975e33ae9f74da7ad16d338769999eb62557df06aa30101e3b5caeR104-R112) [[2]](diffhunk://#diff-9207856edd975e33ae9f74da7ad16d338769999eb62557df06aa30101e3b5caeR122-R130)

**Service Layer and Business Logic:**

* Added logic in `AuthService` to handle email change requests, including validation, rate limiting using `LoginAttemptService`, audit logging, token generation, and sending confirmation emails. Also implemented the confirmation logic to update the user's email after token validation.
* Extended `LoginAttemptService` with methods to check and reset attempt counts for email change requests, supporting account lockout after too many failed attempts.

**Token and Audit Infrastructure:**

* Updated the `Token` model to include a `data` field for storing the pending new email, and added a new `EMAIL_CHANGE` token type. [[1]](diffhunk://#diff-1902063ad3cb0f4db9f79969796f97815fe446bc0cb02e7412f51bb810bacc73R44-R46) [[2]](diffhunk://#diff-00f2e953090ad31f86f271c21feeb3f83d681c44ad34850a0b166837e878d62aL6-R7)
* Extended `TokenRepository` with methods to manage tokens by user and type, supporting the new workflow.
* Added new audit message constants for email change request and confirmation events.