### PR TITLE
Update dependencies to latest

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -10,7 +10,6 @@
     </parent>
 
     <artifactId>oxalate-service-api</artifactId>
-    <version>1.0-SNAPSHOT</version>
     <name>oxalate-service-api</name>
     <description>Oxalate backend server API</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <java.version>25</java.version>
         <spring.boot.version>4.1.0</spring.boot.version> <!-- Keep this in sync with the parent version -->
         <jjwt.version>0.13.0</jjwt.version>
-        <swagger.version>2.2.51</swagger.version>
+        <swagger.version>2.2.52</swagger.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <apache-maven.version>3.5.6</apache-maven.version>
         <jboss-logging.component.version>3.0.4.Final</jboss-logging.component.version>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -10,7 +10,6 @@
     </parent>
 
     <artifactId>oxalate-service</artifactId>
-    <version>1.0-SNAPSHOT</version>
     <name>oxalate-service</name>
     <description>Oxalate backend server</description>
 


### PR DESCRIPTION
This pull request updates dependencies and configuration versions to keep the project up to date and secure. The main changes include upgrading the Maven wrapper and the Swagger dependency version, as well as minor cleanup in the `pom.xml` files.

Dependency and build tool updates:

* Upgraded the Maven wrapper to use version 3.9.16 instead of 3.9.6 in `.mvn/wrapper/maven-wrapper.properties`.
* Updated the Swagger dependency version from 2.2.51 to 2.2.52 in the root `pom.xml`.

Project configuration cleanup:

* Removed redundant `<version>` tags from the `api/pom.xml` and `service/pom.xml` files, likely to rely on the parent POM for version management. [[1]](diffhunk://#diff-f35103f068e191d5d8933637b2d4217d8f90a78728ccab1bada951a8d1c83590L13) [[2]](diffhunk://#diff-e111dd0e82f440d2675d1ad5b10fe3ffde1c976ac42f203065af98550372b13eL13)